### PR TITLE
Bump last upgrade check

### DIFF
--- a/Mocktail.xcodeproj/project.pbxproj
+++ b/Mocktail.xcodeproj/project.pbxproj
@@ -147,7 +147,7 @@
 		A822633616C45BC4007C81BC /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = "Square, Inc";
 			};
 			buildConfigurationList = A822633916C45BC4007C81BC /* Build configuration list for PBXProject "Mocktail" */;


### PR DESCRIPTION
Removes an Xcode warning.

/cc @puls @natan 
