### PR TITLE
Support for mocking only specific files

### DIFF
--- a/Mocktail/Mocktail.h
+++ b/Mocktail/Mocktail.h
@@ -22,6 +22,22 @@
  */
 + (instancetype)startWithContentsOfDirectoryAtURL:(NSURL *)url;
 
+/** Creates and starts a new Mocktail instance, reading a single `.tail` file at a url.
+ 
+ @param url URL to a file on the filesystem. Must be a `.tail` file.
+ 
+ @return an instantiated Mocktail instance.
+ */
++ (instancetype)startWithFileAtURL:(NSURL *)url;
+
+/** Creates and starts a new Mocktail instance, reading in the `.tail` files at the URLs passed.
+ 
+ @param urlArray An array of NSURLs pointing to `.tail` files. Items that are not NSURLs or don't point to a `.tail` file will be ignored.
+ 
+ @return an instantiated Mocktail instance.
+ */
++ (instancetype)startWithFilesAtURLs:(NSArray *)urlArray;
+
 /** Stops the Mocktail instance from responding to requests.
  */
 - (void)stop;

--- a/Mocktail/Mocktail.m
+++ b/Mocktail/Mocktail.m
@@ -47,6 +47,23 @@ static NSMutableSet *_allMocktails;
     return mocktail;
 }
 
++ (instancetype)startWithFileAtURL:(NSURL *)url
+{
+    return [self startWithFilesAtURLs:@[url]];
+}
+
++ (instancetype)startWithFilesAtURLs:(NSArray *)urlArray
+{
+    Mocktail *mocktail = [self new];
+    for (NSURL *url in urlArray) {
+        if ([url isKindOfClass:[NSURL class]]) {
+            [mocktail registerFileAtURL:url];
+        }
+    }
+    [mocktail start];
+    return mocktail;
+}
+
 - (id)init;
 {
     self = [super init];


### PR DESCRIPTION
I need different responses for the same url matcher, so it was necessary to be specific about which exact files I wanted per mock. This pull adds 2 new methods, startWithFilesAtURLs and startWithFileAtURL, for starting a mocktail instance without a directory, allowing you to choose which .tail files to load.