### PR TITLE
Add method for clearing all mocktails

### DIFF
--- a/Mocktail/Mocktail.h
+++ b/Mocktail/Mocktail.h
@@ -33,6 +33,10 @@
  */
 - (void)stop;
 
+/** Clears all mocktails from the internal collection, effectively resetting Mocktail to it's initial state.
+ */
++ (void)clearMocktails;
+
 /** Additional latency to add before sending back mock responses. Useful for simulating a bad network, or at least for simulating real-world performance.
  
  Default value is 0.0.

--- a/Mocktail/Mocktail.m
+++ b/Mocktail/Mocktail.m
@@ -161,6 +161,11 @@ static NSMutableSet *_allMocktails;
     }
 }
 
++ (void)clearMocktails
+{
+    [[Mocktail allMocktails] removeAllObjects];
+}
+
 #pragma mark - Parsing files
 
 - (void)registerContentsOfDirectoryAtURL:(NSURL *)url;


### PR DESCRIPTION
Adds a `clearMocktails` method for resetting the state of Mocktail
