### PR TITLE
Uplift MocktailResponse to take an error parameter

### DIFF
--- a/Mocktail/Mocktail.m
+++ b/Mocktail/Mocktail.m
@@ -223,9 +223,9 @@ static NSMutableSet *_allMocktails;
 
     if (mocktailResponseError) {
         if (mocktailResponseError.code == MocktailResponseErrorOpeningFile) {
-            NSLog(@"Error opening %@: %@", url, mocktailResponseError.userInfo[@"fileError"]);
+            NSLog(@"Error opening %@: %@", url, mocktailResponseError.userInfo[kFileErrorUserDataKey]);
         } else if (mocktailResponseError.code == MocktailResponseErrorNumberOfLines) {
-            NSLog(@"Invalid amount of lines: %u", (unsigned)[mocktailResponseError.userInfo[@"lines"] count]);
+            NSLog(@"Invalid amount of lines: %u", (unsigned)[mocktailResponseError.userInfo[kNumberOfLinesErrorUserDataKey] count]);
         }
     }
 

--- a/Mocktail/Mocktail.m
+++ b/Mocktail/Mocktail.m
@@ -218,7 +218,16 @@ static NSMutableSet *_allMocktails;
 
 - (void)registerFileAtURL:(NSURL *)url;
 {
-    MocktailResponse *response = [MocktailResponse mocktailResponseForFileAtURL:url];
+    NSError *mocktailResponseError;
+    MocktailResponse *response = [MocktailResponse mocktailResponseForFileAtURL:url error:&mocktailResponseError];
+
+    if (mocktailResponseError) {
+        if (mocktailResponseError.code == MocktailResponseErrorOpeningFile) {
+            NSLog(@"Error opening %@: %@", url, mocktailResponseError.userInfo[@"fileError"]);
+        } else if (mocktailResponseError.code == MocktailResponseErrorNumberOfLines) {
+            NSLog(@"Invalid amount of lines: %u", (unsigned)[mocktailResponseError.userInfo[@"lines"] count]);
+        }
+    }
 
     @synchronized (_mutableMockResponses) {
         if (response) {

--- a/Mocktail/MocktailResponse.h
+++ b/Mocktail/MocktailResponse.h
@@ -10,6 +10,8 @@
 #import <Foundation/Foundation.h>
 
 extern NSString *const kMocktailResponseErrorDomain;
+extern NSString *const kFileErrorUserDataKey;
+extern NSString *const kNumberOfLinesErrorUserDataKey;
 
 typedef NS_ENUM(NSInteger, MockTailResponseError) {
     MocktailResponseErrorOpeningFile,

--- a/Mocktail/MocktailResponse.h
+++ b/Mocktail/MocktailResponse.h
@@ -15,12 +15,18 @@
 
 @interface MocktailResponse : NSObject
 
-@property (nonatomic, strong) NSRegularExpression *methodRegex;
-@property (nonatomic, strong) NSRegularExpression *absoluteURLRegex;
-@property (nonatomic, strong) NSURL *fileURL;
-@property (nonatomic) NSInteger bodyOffset;
-@property (nonatomic, strong) NSDictionary *headers;
-@property (nonatomic) NSInteger statusCode;
+@property (nonatomic, strong, readonly) NSRegularExpression *methodRegex;
+@property (nonatomic, strong, readonly) NSRegularExpression *absoluteURLRegex;
+@property (nonatomic, strong, readonly) NSURL *fileURL;
+@property (nonatomic, readonly) NSInteger bodyOffset;
+@property (nonatomic, strong, readonly) NSDictionary *headers;
+@property (nonatomic, readonly) NSInteger statusCode;
 @property (nonatomic, weak) Mocktail *mocktail;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithFileAtURL:(NSURL *)fileURL NS_DESIGNATED_INITIALIZER;
+
++ (MocktailResponse *)mocktailResponseForFileAtURL:(NSURL *)url;
 
 @end

--- a/Mocktail/MocktailResponse.h
+++ b/Mocktail/MocktailResponse.h
@@ -9,9 +9,14 @@
 
 #import <Foundation/Foundation.h>
 
+extern NSString *const kMocktailResponseErrorDomain;
+
+typedef NS_ENUM(NSInteger, MockTailResponseError) {
+    MocktailResponseErrorOpeningFile,
+    MocktailResponseErrorNumberOfLines
+};
 
 @class Mocktail;
-
 
 @interface MocktailResponse : NSObject
 
@@ -25,8 +30,8 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithFileAtURL:(NSURL *)fileURL NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithFileAtURL:(NSURL *)fileURL error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
-+ (MocktailResponse *)mocktailResponseForFileAtURL:(NSURL *)url;
++ (MocktailResponse *)mocktailResponseForFileAtURL:(NSURL *)url error:(NSError **)error;
 
 @end

--- a/Mocktail/MocktailResponse.m
+++ b/Mocktail/MocktailResponse.m
@@ -11,5 +11,60 @@
 #import "MocktailResponse.h"
 
 
+@interface MocktailResponse()
+
+@property (nonatomic, strong) NSRegularExpression *methodRegex;
+@property (nonatomic, strong) NSRegularExpression *absoluteURLRegex;
+@property (nonatomic, strong) NSURL *fileURL;
+@property (nonatomic) NSInteger bodyOffset;
+@property (nonatomic, strong) NSDictionary *headers;
+@property (nonatomic) NSInteger statusCode;
+
+@end
+
+
 @implementation MocktailResponse
+
+- (instancetype)initWithFileAtURL:(NSURL *)url {
+    self = [super init];
+    if (self) {
+        NSError *error;
+        NSStringEncoding originalEncoding;
+        NSString *contentsOfFile = [NSString stringWithContentsOfURL:url usedEncoding:&originalEncoding error:&error];
+        if (error) {
+            NSLog(@"Error opening %@: %@", url, error);
+            return nil;
+        }
+
+        NSScanner *scanner = [NSScanner scannerWithString:contentsOfFile];
+        NSString *headerMatter = nil;
+        [scanner scanUpToString:@"\n\n" intoString:&headerMatter];
+        NSArray *lines = [headerMatter componentsSeparatedByString:@"\n"];
+        if ([lines count] < 4) {
+            NSLog(@"Invalid amount of lines: %u", (unsigned)[lines count]);
+            return nil;
+        }
+
+        _methodRegex = [NSRegularExpression regularExpressionWithPattern:lines[0] options:NSRegularExpressionCaseInsensitive error:nil];
+        _absoluteURLRegex = [NSRegularExpression regularExpressionWithPattern:lines[1] options:NSRegularExpressionCaseInsensitive error:nil];
+        _statusCode = [lines[2] integerValue];
+        NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+        for (NSString *line in [lines subarrayWithRange:NSMakeRange(3, lines.count - 3)]) {
+            NSArray* parts = [line componentsSeparatedByString:@":"];
+            headers[[parts firstObject]] = [[parts lastObject] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        }
+        _headers = headers;
+        _fileURL = url;
+        _bodyOffset = [headerMatter dataUsingEncoding:originalEncoding].length + 2;
+    }
+
+    return self;
+}
+
++ (MocktailResponse *)mocktailResponseForFileAtURL:(NSURL *)url {
+    NSAssert(url, @"Expected valid URL.");
+
+    return [[MocktailResponse alloc] initWithFileAtURL:url];
+}
+
 @end

--- a/Mocktail/MocktailResponse.m
+++ b/Mocktail/MocktailResponse.m
@@ -10,7 +10,6 @@
 
 #import "MocktailResponse.h"
 
-
 @interface MocktailResponse()
 
 @property (nonatomic, strong) NSRegularExpression *methodRegex;
@@ -22,17 +21,21 @@
 
 @end
 
+NSString *const kMocktailResponseErrorDomain = @"MocktailResponseError";
+static NSUInteger const kNumLinesRequired = 4;
 
 @implementation MocktailResponse
 
-- (instancetype)initWithFileAtURL:(NSURL *)url {
+- (instancetype)initWithFileAtURL:(NSURL *)url error:(NSError *__autoreleasing *)error {
     self = [super init];
     if (self) {
-        NSError *error;
+        NSError *fileError;
         NSStringEncoding originalEncoding;
-        NSString *contentsOfFile = [NSString stringWithContentsOfURL:url usedEncoding:&originalEncoding error:&error];
-        if (error) {
-            NSLog(@"Error opening %@: %@", url, error);
+        NSString *contentsOfFile = [NSString stringWithContentsOfURL:url usedEncoding:&originalEncoding error:&fileError];
+        if (fileError) {
+            *error = [[NSError alloc] initWithDomain:kMocktailResponseErrorDomain
+                                                code:MocktailResponseErrorOpeningFile
+                                            userInfo:@{@"fileError": fileError}];
             return nil;
         }
 
@@ -40,8 +43,10 @@
         NSString *headerMatter = nil;
         [scanner scanUpToString:@"\n\n" intoString:&headerMatter];
         NSArray *lines = [headerMatter componentsSeparatedByString:@"\n"];
-        if ([lines count] < 4) {
-            NSLog(@"Invalid amount of lines: %u", (unsigned)[lines count]);
+        if ([lines count] < kNumLinesRequired) {
+            *error = [[NSError alloc] initWithDomain:kMocktailResponseErrorDomain
+                                                code:MocktailResponseErrorNumberOfLines
+                                            userInfo:@{@"lines": lines}];
             return nil;
         }
 
@@ -61,10 +66,10 @@
     return self;
 }
 
-+ (MocktailResponse *)mocktailResponseForFileAtURL:(NSURL *)url {
++ (MocktailResponse *)mocktailResponseForFileAtURL:(NSURL *)url error:(NSError *__autoreleasing *)error {
     NSAssert(url, @"Expected valid URL.");
 
-    return [[MocktailResponse alloc] initWithFileAtURL:url];
+    return [[MocktailResponse alloc] initWithFileAtURL:url error:error];
 }
 
 @end

--- a/Mocktail/MocktailResponse.m
+++ b/Mocktail/MocktailResponse.m
@@ -22,6 +22,8 @@
 @end
 
 NSString *const kMocktailResponseErrorDomain = @"MocktailResponseError";
+NSString *const kFileErrorUserDataKey = @"fileError";
+NSString *const kNumberOfLinesErrorUserDataKey = @"lines";
 static NSUInteger const kNumLinesRequired = 4;
 
 @implementation MocktailResponse
@@ -35,7 +37,7 @@ static NSUInteger const kNumLinesRequired = 4;
         if (fileError) {
             *error = [[NSError alloc] initWithDomain:kMocktailResponseErrorDomain
                                                 code:MocktailResponseErrorOpeningFile
-                                            userInfo:@{@"fileError": fileError}];
+                                            userInfo:@{kFileErrorUserDataKey: fileError}];
             return nil;
         }
 
@@ -46,7 +48,7 @@ static NSUInteger const kNumLinesRequired = 4;
         if ([lines count] < kNumLinesRequired) {
             *error = [[NSError alloc] initWithDomain:kMocktailResponseErrorDomain
                                                 code:MocktailResponseErrorNumberOfLines
-                                            userInfo:@{@"lines": lines}];
+                                            userInfo:@{kNumberOfLinesErrorUserDataKey: lines}];
             return nil;
         }
 


### PR DESCRIPTION
@nicholascross

To address a potential nil value getting returned from MocktailResponse. Allow MocktailResponse to take an error pointer parameter to address what went wrong.

Also moves error handling from inside MocktailResponse.m back to Mocktail.m